### PR TITLE
ref: add macro to dedup tests in sorting algorithms

### DIFF
--- a/src/sorting/bubble_sort.rs
+++ b/src/sorting/bubble_sort.rs
@@ -12,24 +12,5 @@ pub fn bubble_sort<T: Ord>(array: &mut [T]) {
 mod tests {
     use super::bubble_sort;
 
-    #[test]
-    fn basic() {
-        let mut array = [5, 4, 1, 6, 0];
-        bubble_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-        bubble_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut array = [1, 2, 3, 4, 5, 6];
-        bubble_sort(&mut array);
-        assert_sorted!(&array);
-    }
+    sorting_tests!(bubble_sort, inplace);
 }

--- a/src/sorting/counting_sort.rs
+++ b/src/sorting/counting_sort.rs
@@ -47,12 +47,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn basic() {
-        let array = [5, 4, 1, 6, 0];
-        let output = counting_sort(&array);
-        assert_sorted!(&output);
-    }
+    sorting_tests!(counting_sort);
 
     #[test]
     fn basic_struct() {
@@ -69,13 +64,6 @@ mod tests {
     }
 
     #[test]
-    fn repeated_elements() {
-        let array = [5, 5, 1, 6, 1, 0, 2, 6];
-        let output = counting_sort(&array);
-        assert_sorted!(&output);
-    }
-
-    #[test]
     fn repeated_elements_struct() {
         let array = [
             Custom { key: 5 },
@@ -87,13 +75,6 @@ mod tests {
             Custom { key: 2 },
             Custom { key: 6 },
         ];
-        let output = counting_sort(&array);
-        assert_sorted!(&output);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let array = [1, 2, 3, 4, 5, 6];
         let output = counting_sort(&array);
         assert_sorted!(&output);
     }

--- a/src/sorting/heap_sort.rs
+++ b/src/sorting/heap_sort.rs
@@ -45,24 +45,5 @@ fn siftdown<T: Ord>(array: &mut [T], mut root: usize, end: usize) {
 mod tests {
     use super::heap_sort;
 
-    #[test]
-    fn basic() {
-        let mut array = [5, 4, 1, 6, 0];
-        heap_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-        heap_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut array = [1, 2, 3, 4, 5, 6];
-        heap_sort(&mut array);
-        assert_sorted!(&array);
-    }
+    sorting_tests!(heap_sort, inplace);
 }

--- a/src/sorting/insertion_sort.rs
+++ b/src/sorting/insertion_sort.rs
@@ -12,24 +12,5 @@ pub fn insertion_sort<T: Ord>(array: &mut [T]) {
 mod tests {
     use super::insertion_sort;
 
-    #[test]
-    fn basic() {
-        let mut array = [5, 4, 1, 6, 0];
-        insertion_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-        insertion_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut array = [1, 2, 3, 4, 5, 6];
-        insertion_sort(&mut array);
-        assert_sorted!(&array);
-    }
+    sorting_tests!(insertion_sort, inplace);
 }

--- a/src/sorting/macros.rs
+++ b/src/sorting/macros.rs
@@ -11,3 +11,52 @@ macro_rules! assert_not_sorted {
         assert!(!$crate::sorting::is_sorted($iter));
     };
 }
+
+macro_rules! sorting_tests {
+    ($sorter: expr, inplace) => {
+        #[test]
+        fn basic() {
+                let mut array = [5, 4, 1, 6, 0];
+                $sorter(&mut array);
+                assert_sorted!(&array);
+        }
+
+        #[test]
+        fn repeated_elements() {
+                let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
+                $sorter(&mut array);
+                assert_sorted!(&array);
+        }
+
+        #[test]
+        fn pre_sorted() {
+                let mut array = [1, 2, 3, 4, 5, 6];
+                $sorter(&mut array);
+                assert_sorted!(&array);
+        }
+    };
+
+    ($sorter: expr) => {
+        #[test]
+        fn basic() {
+                let array = [5, 4, 1, 6, 0];
+                let output = $sorter(&array);
+                assert_sorted!(&output);
+        }
+
+        #[test]
+        fn repeated_elements() {
+                let array = [5, 5, 1, 6, 1, 0, 2, 6];
+                let output = $sorter(&array);
+                assert_sorted!(&output);
+        }
+
+        #[test]
+        fn pre_sorted() {
+                let array = [1, 2, 3, 4, 5, 6];
+                let output = $sorter(&array);
+                assert_sorted!(&output);
+        }
+    };
+
+}

--- a/src/sorting/merge_sort.rs
+++ b/src/sorting/merge_sort.rs
@@ -35,24 +35,5 @@ fn merge<T: Ord + Copy>(left: &mut Vec<T>, right: &mut Vec<T>) -> Vec<T> {
 mod tests {
     use super::merge_sort;
 
-    #[test]
-    fn basic() {
-        let array = [5, 4, 1, 6, 0];
-        let result = merge_sort(&array);
-        assert_sorted!(result);
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-        let result = merge_sort(&mut array);
-        assert_sorted!(result);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut array = [1, 2, 3, 4, 5, 6];
-        let result = merge_sort(&mut array);
-        assert_sorted!(result);
-    }
+    sorting_tests!(merge_sort);
 }

--- a/src/sorting/quick_sort.rs
+++ b/src/sorting/quick_sort.rs
@@ -39,24 +39,5 @@ pub fn quick_sort<T: Ord>(array: &mut [T]) {
 mod tests {
     use super::quick_sort;
 
-    #[test]
-    fn basic() {
-        let mut array = [5, 4, 1, 6, 0];
-        quick_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-        quick_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut array = [1, 2, 3, 4, 5, 6];
-        quick_sort(&mut array);
-        assert_sorted!(&array);
-    }
+    sorting_tests!(quick_sort, inplace);
 }

--- a/src/sorting/selection_sort.rs
+++ b/src/sorting/selection_sort.rs
@@ -15,24 +15,5 @@ pub fn selection_sort<T: Ord>(array: &mut [T]) {
 mod tests {
     use super::selection_sort;
 
-    #[test]
-    fn basic() {
-        let mut array = [5, 4, 1, 6, 0];
-        selection_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-        selection_sort(&mut array);
-        assert_sorted!(&array);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut array = [1, 2, 3, 4, 5, 6];
-        selection_sort(&mut array);
-        assert_sorted!(&array);
-    }
+    sorting_tests!(selection_sort, inplace);
 }


### PR DESCRIPTION
In #19 has been pointed out that a new macro that represents the test suite for sorting algorithms could be used to avoid code duplication in tests for sorting algorithms. 

The changes introduced by this PR are the following:

1. introduction of the `sorting_tests!` macro, which represents the test previously done through the `basic`, `repeated_elements` and `pre_sorted` functions
2. the macro can be used in two ways:
    1. `sorting_tests!(sorting_function)`, for algorithms implemented without in-place implementation
    2. `sorting_tests!(sorting_function, inplace)`, for algorithms with in-place implementation
3. all the implemented sorting algorithms now use the `sorting_tests!` with two excpetions:
    1. _radix sort_ uses a different test suite
    2. _shell sort_ uses only the `basic` test function and the `pre_sorted` has a different name (`already_sorted` in this case)

The total number of tests run with `cargo test` remains 129