### PR TITLE
feat: add docs to stack (vector)

### DIFF
--- a/src/data_structures/README.md
+++ b/src/data_structures/README.md
@@ -77,6 +77,18 @@ __Source to read:__
 * [Stack Implementation and complexity](https://medium.com/@kaichimomose/stack-implementation-and-complexity-c176924e6a6b)
 
 
+### [Stack (vector impl)](./stack.rs)
+
+When backed by a vector (or other contiguous data structure), a stack can keep tabs of its size and change that size.
+
+__Properties__
+* Push O(1)
+* Pop O(1)
+* Peek O(1)
+
+__Sources to read:__
+* [Stack (abstract data type)](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)#Array)
+
 
 [doubly-linked-list]: https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Doubly-linked-list.svg/610px-Doubly-linked-list.svg.png
 

--- a/src/data_structures/stack.rs
+++ b/src/data_structures/stack.rs
@@ -1,29 +1,38 @@
+// a vector-based implementation of the stack data type
 pub struct Stack<T> {
     vec: Vec<T>,
 }
 
 impl<T> Stack<T> {
+    // a constructor that returns an instance of Stack<T> backed by an empty Vec<T>
     pub fn new() -> Self {
         Stack { vec: Vec::new() }
     }
 
+    // mutates the stack by adding an item of type T and returns true
     pub fn push(&mut self, item: T) -> bool {
         self.vec.push(item);
         true
     }
 
+    // returns the number of elements in the stack
     pub fn len(&self) -> usize {
         self.vec.len()
     }
 
+    // returns true if stack is empty else false
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
     }
 
+    // returns a Some<&T> if stack is non-empty else None
+    // &T is an immutable reference to an element of type T
     pub fn peek(&self) -> Option<&T> {
         self.vec.last()
     }
 
+    // mutates the stack by removing and returning a Some<T>
+    // if stack is non-empty else None
     pub fn pop(&mut self) -> Option<T> {
         self.vec.pop()
     }


### PR DESCRIPTION
Hi, hope these comments are okay. I didn't change it with this commit but I did notice that in the `src/data_structures/README.md` that the `Properties` section for the linked list stack says that accessing the tail happens in `O(n)` time. This doesn't seem particularly relevant to stacks, though?