### PR TITLE
feat: add `sorting_tests` macro to almost all sorting algorithms

### DIFF
--- a/src/sorting/bogo_sort.rs
+++ b/src/sorting/bogo_sort.rs
@@ -49,25 +49,7 @@ pub fn bogo_sort<T: Ord>(arr: &mut [T]) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::bogo_sort;
 
-    #[test]
-    fn random_array() {
-        let mut arr = [1, 8, 3, 2, 7, 4, 6, 5];
-        bogo_sort(&mut arr);
-
-        for i in 0..arr.len() - 1 {
-            assert!(arr[i] <= arr[i + 1]);
-        }
-    }
-
-    #[test]
-    fn sorted_array() {
-        let mut arr = [1, 2, 3, 4, 5, 6, 7, 8];
-        bogo_sort(&mut arr);
-
-        for i in 0..arr.len() - 1 {
-            assert!(arr[i] <= arr[i + 1]);
-        }
-    }
+    sorting_tests!(bogo_sort, inplace);
 }

--- a/src/sorting/bucket_sort.rs
+++ b/src/sorting/bucket_sort.rs
@@ -36,6 +36,8 @@ mod tests {
     use super::super::is_sorted;
     use super::*;
 
+    sorting_tests!(bucket_sort);
+
     #[test]
     fn empty() {
         let arr: [usize; 0] = [];
@@ -51,29 +53,8 @@ mod tests {
     }
 
     #[test]
-    fn already_sorted() {
-        let arr: [usize; 3] = [10, 9, 105];
-        let res = bucket_sort(&arr);
-        assert!(is_sorted(&res));
-    }
-
-    #[test]
-    fn basic() {
-        let arr: [usize; 4] = [35, 53, 1, 0];
-        let res = bucket_sort(&arr);
-        assert!(is_sorted(&res));
-    }
-
-    #[test]
     fn odd_number_of_elements() {
         let arr: Vec<usize> = vec![1, 21, 5, 11, 58];
-        let res = bucket_sort(&arr);
-        assert!(is_sorted(&res));
-    }
-
-    #[test]
-    fn repeated_elements() {
-        let arr: Vec<usize> = vec![542, 542, 542, 542];
         let res = bucket_sort(&arr);
         assert!(is_sorted(&res));
     }

--- a/src/sorting/cocktail_shaker_sort.rs
+++ b/src/sorting/cocktail_shaker_sort.rs
@@ -38,12 +38,7 @@ pub fn cocktail_shaker_sort<T: Ord>(arr: &mut [T]) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let mut arr = vec![5, 2, 1, 3, 4, 6];
-        cocktail_shaker_sort(&mut arr);
-        assert_eq!(arr, vec![1, 2, 3, 4, 5, 6]);
-    }
+    sorting_tests!(cocktail_shaker_sort, inplace);
 
     #[test]
     fn empty() {
@@ -57,12 +52,5 @@ mod tests {
         let mut arr = vec![1];
         cocktail_shaker_sort(&mut arr);
         assert_eq!(arr, vec![1]);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut arr = vec![1, 2, 3, 4, 5, 6];
-        cocktail_shaker_sort(&mut arr);
-        assert_eq!(arr, vec![1, 2, 3, 4, 5, 6]);
     }
 }

--- a/src/sorting/comb_sort.rs
+++ b/src/sorting/comb_sort.rs
@@ -23,6 +23,8 @@ pub fn comb_sort<T: Ord>(arr: &mut [T]) {
 mod tests {
     use super::*;
 
+    sorting_tests!(comb_sort, inplace);
+
     #[test]
     fn descending() {
         //descending

--- a/src/sorting/counting_sort.rs
+++ b/src/sorting/counting_sort.rs
@@ -30,6 +30,8 @@ mod tests {
     use super::counting_sort;
     use super::Keyed;
 
+    sorting_tests!(counting_sort);
+
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Default)]
     struct Custom {
         key: usize,
@@ -46,8 +48,6 @@ mod tests {
             *self
         }
     }
-
-    sorting_tests!(counting_sort);
 
     #[test]
     fn basic_struct() {

--- a/src/sorting/cycle_sort.rs
+++ b/src/sorting/cycle_sort.rs
@@ -35,6 +35,9 @@ pub fn cycle_sort(arr: &mut [i32]) {
 mod tests {
     use super::super::is_sorted;
     use super::*;
+
+    sorting_tests!(cycle_sort, inplace);
+    
     #[test]
     fn it_works() {
         let mut arr1 = [6, 5, 4, 3, 2, 1];

--- a/src/sorting/cycle_sort.rs
+++ b/src/sorting/cycle_sort.rs
@@ -37,7 +37,7 @@ mod tests {
     use super::*;
 
     sorting_tests!(cycle_sort, inplace);
-    
+
     #[test]
     fn it_works() {
         let mut arr1 = [6, 5, 4, 3, 2, 1];

--- a/src/sorting/exchange_sort.rs
+++ b/src/sorting/exchange_sort.rs
@@ -15,6 +15,9 @@ pub fn exchange_sort(arr: &mut [i32]) {
 mod tests {
     use super::super::is_sorted;
     use super::*;
+
+    sorting_tests!(exchange_sort, inplace);
+
     #[test]
     fn it_works() {
         let mut arr1 = [6, 5, 4, 3, 2, 1];

--- a/src/sorting/gnome_sort.rs
+++ b/src/sorting/gnome_sort.rs
@@ -28,17 +28,7 @@ where
 mod tests {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let res = gnome_sort(&vec![6, 5, -8, 3, 2, 3]);
-        assert_eq!(res, vec![-8, 2, 3, 3, 5, 6]);
-    }
-
-    #[test]
-    fn already_sorted() {
-        let res = gnome_sort(&vec!["a", "b", "c"]);
-        assert_eq!(res, vec!["a", "b", "c"]);
-    }
+    sorting_tests!(gnome_sort);
 
     #[test]
     fn odd_number_of_elements() {

--- a/src/sorting/macros.rs
+++ b/src/sorting/macros.rs
@@ -16,47 +16,46 @@ macro_rules! sorting_tests {
     ($sorter: expr, inplace) => {
         #[test]
         fn basic() {
-                let mut array = [5, 4, 1, 6, 0];
-                $sorter(&mut array);
-                assert_sorted!(&array);
+            let mut array = [5, 4, 1, 6, 0];
+            $sorter(&mut array);
+            assert_sorted!(&array);
         }
 
         #[test]
         fn repeated_elements() {
-                let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
-                $sorter(&mut array);
-                assert_sorted!(&array);
+            let mut array = [5, 5, 1, 6, 1, 0, 2, 6];
+            $sorter(&mut array);
+            assert_sorted!(&array);
         }
 
         #[test]
         fn pre_sorted() {
-                let mut array = [1, 2, 3, 4, 5, 6];
-                $sorter(&mut array);
-                assert_sorted!(&array);
+            let mut array = [1, 2, 3, 4, 5, 6];
+            $sorter(&mut array);
+            assert_sorted!(&array);
         }
     };
 
     ($sorter: expr) => {
         #[test]
         fn basic() {
-                let array = [5, 4, 1, 6, 0];
-                let output = $sorter(&array);
-                assert_sorted!(&output);
+            let array = [5, 4, 1, 6, 0];
+            let output = $sorter(&array);
+            assert_sorted!(&output);
         }
 
         #[test]
         fn repeated_elements() {
-                let array = [5, 5, 1, 6, 1, 0, 2, 6];
-                let output = $sorter(&array);
-                assert_sorted!(&output);
+            let array = [5, 5, 1, 6, 1, 0, 2, 6];
+            let output = $sorter(&array);
+            assert_sorted!(&output);
         }
 
         #[test]
         fn pre_sorted() {
-                let array = [1, 2, 3, 4, 5, 6];
-                let output = $sorter(&array);
-                assert_sorted!(&output);
+            let array = [1, 2, 3, 4, 5, 6];
+            let output = $sorter(&array);
+            assert_sorted!(&output);
         }
     };
-
 }

--- a/src/sorting/odd_even_sort.rs
+++ b/src/sorting/odd_even_sort.rs
@@ -28,12 +28,7 @@ pub fn odd_even_sort<T: Ord>(arr: &mut [T]) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let mut arr = vec![3, 5, 1, 2, 4, 6];
-        odd_even_sort(&mut arr);
-        assert_eq!(arr, vec![1, 2, 3, 4, 5, 6]);
-    }
+    sorting_tests!(odd_even_sort, inplace);
 
     #[test]
     fn empty() {
@@ -47,12 +42,5 @@ mod tests {
         let mut arr = vec![3];
         odd_even_sort(&mut arr);
         assert_eq!(arr, vec![3]);
-    }
-
-    #[test]
-    fn pre_sorted() {
-        let mut arr = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        odd_even_sort(&mut arr);
-        assert_eq!(arr, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 }

--- a/src/sorting/pancake_sort.rs
+++ b/src/sorting/pancake_sort.rs
@@ -28,17 +28,7 @@ where
 mod tests {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let res = pancake_sort(&mut vec![6, 5, -8, 3, 2, 3]);
-        assert_eq!(res, vec![-8, 2, 3, 3, 5, 6]);
-    }
-
-    #[test]
-    fn already_sorted() {
-        let res = pancake_sort(&mut vec!["a", "b", "c"]);
-        assert_eq!(res, vec!["a", "b", "c"]);
-    }
+    sorting_tests!(pancake_sort, inplace);
 
     #[test]
     fn odd_number_of_elements() {

--- a/src/sorting/radix_sort.rs
+++ b/src/sorting/radix_sort.rs
@@ -38,6 +38,8 @@ pub fn radix_sort(arr: &mut [u64]) {
 mod tests {
     use super::radix_sort;
 
+    sorting_tests!(radix_sort, inplace);
+
     #[test]
     fn empty() {
         let mut a: [u64; 0] = [];

--- a/src/sorting/shell_sort.rs
+++ b/src/sorting/shell_sort.rs
@@ -1,3 +1,5 @@
+/* NOTE: maybe it'd be a good idea to standardize the function signatures as well?
+ * since with this signature, the `sorting_tests` macro doesn't work */
 pub fn shell_sort<T: Ord + Copy>(values: &mut Vec<T>) {
     // shell sort works by swiping the value at a given gap and decreasing the gap to 1
     fn insertion<T: Ord + Copy>(values: &mut Vec<T>, start: usize, gap: usize) {

--- a/src/sorting/stooge_sort.rs
+++ b/src/sorting/stooge_sort.rs
@@ -27,14 +27,7 @@ pub fn stooge_sort<T: Ord>(arr: &mut [T]) {
 mod test {
     use super::*;
 
-    #[test]
-    fn basic() {
-        let mut vec = vec![3, 5, 6, 3, 1, 4];
-        stooge_sort(&mut vec);
-        for i in 0..vec.len() - 1 {
-            assert!(vec[i] <= vec[i + 1]);
-        }
-    }
+    sorting_tests!(stooge_sort, inplace);
 
     #[test]
     fn empty() {
@@ -46,15 +39,6 @@ mod test {
     #[test]
     fn reverse() {
         let mut vec = vec![6, 5, 4, 3, 2, 1];
-        stooge_sort(&mut vec);
-        for i in 0..vec.len() - 1 {
-            assert!(vec[i] <= vec[i + 1]);
-        }
-    }
-
-    #[test]
-    fn already_sorted() {
-        let mut vec = vec![1, 2, 3, 4, 5, 6];
         stooge_sort(&mut vec);
         for i in 0..vec.len() - 1 {
             assert!(vec[i] <= vec[i + 1]);


### PR DESCRIPTION
There were a few algorithms I wasn't able to do this for, because the function signatures didn't match those expected by the macro. Perhaps it'd be a good idea to standardize those too?