### PR TITLE
refactor(sorting): add traits for sorting algorithms

### DIFF
--- a/src/sorting/bogo_sort.rs
+++ b/src/sorting/bogo_sort.rs
@@ -1,10 +1,10 @@
-use super::traits::SortMutable;
+use super::traits::MutableSorter;
 use crate::math::PCG32;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const DEFAULT: u64 = 4294967296;
 
-pub struct BogoSort();
+pub struct BogoSort;
 
 impl BogoSort {
     fn is_sorted<T: Ord>(arr: &[T], len: usize) -> bool {
@@ -37,8 +37,11 @@ impl BogoSort {
     }
 }
 
-impl<T: Ord> SortMutable<T> for BogoSort {
-    fn sort(arr: &mut [T]) {
+impl<T> MutableSorter<T> for BogoSort {
+    fn sort(arr: &mut [T])
+    where
+        T: Ord,
+    {
         let seed = match SystemTime::now().duration_since(UNIX_EPOCH) {
             Ok(duration) => duration.as_millis() as u64,
             Err(_) => DEFAULT,
@@ -55,7 +58,7 @@ impl<T: Ord> SortMutable<T> for BogoSort {
 
 #[cfg(test)]
 mod tests {
-    use super::super::traits::SortMutable;
+    use super::super::traits::MutableSorter;
     use super::BogoSort;
 
     sorting_tests!(BogoSort::sort, inplace);

--- a/src/sorting/bogo_sort.rs
+++ b/src/sorting/bogo_sort.rs
@@ -1,55 +1,62 @@
+use super::traits::SortMutable;
 use crate::math::PCG32;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const DEFAULT: u64 = 4294967296;
 
-fn is_sorted<T: Ord>(arr: &[T], len: usize) -> bool {
-    for i in 0..len - 1 {
-        if arr[i] > arr[i + 1] {
-            return false;
+pub struct BogoSort();
+
+impl BogoSort {
+    fn is_sorted<T: Ord>(arr: &[T], len: usize) -> bool {
+        for i in 0..len - 1 {
+            if arr[i] > arr[i + 1] {
+                return false;
+            }
+        }
+
+        true
+    }
+    #[cfg(target_pointer_width = "64")]
+    fn generate_index(range: usize, generator: &mut PCG32) -> usize {
+        generator.get_u64() as usize % range
+    }
+
+    #[cfg(not(target_pointer_width = "64"))]
+    fn generate_index(range: usize, generator: &mut PCG32) -> usize {
+        generator.get_u32() as usize % range
+    }
+
+    /**
+     * Fisher–Yates shuffle for generating random permutation.
+     */
+    fn permute_randomly<T>(arr: &mut [T], len: usize, generator: &mut PCG32) {
+        for i in (1..len).rev() {
+            let j = BogoSort::generate_index(i + 1, generator);
+            arr.swap(i, j);
         }
     }
-
-    true
 }
 
-#[cfg(target_pointer_width = "64")]
-fn generate_index(range: usize, generator: &mut PCG32) -> usize {
-    generator.get_u64() as usize % range
-}
+impl<T: Ord> SortMutable<T> for BogoSort {
+    fn sort(arr: &mut [T]) {
+        let seed = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_millis() as u64,
+            Err(_) => DEFAULT,
+        };
 
-#[cfg(not(target_pointer_width = "64"))]
-fn generate_index(range: usize, generator: &mut PCG32) -> usize {
-    generator.get_u32() as usize % range
-}
+        let mut random_generator = PCG32::new_default(seed);
 
-/**
- * Fisher–Yates shuffle for generating random permutation.
- */
-fn permute_randomly<T>(arr: &mut [T], len: usize, generator: &mut PCG32) {
-    for i in (1..len).rev() {
-        let j = generate_index(i + 1, generator);
-        arr.swap(i, j);
-    }
-}
-
-pub fn bogo_sort<T: Ord>(arr: &mut [T]) {
-    let seed = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(duration) => duration.as_millis() as u64,
-        Err(_) => DEFAULT,
-    };
-
-    let mut random_generator = PCG32::new_default(seed);
-
-    let arr_length = arr.len();
-    while !is_sorted(arr, arr_length) {
-        permute_randomly(arr, arr_length, &mut random_generator);
+        let arr_length = arr.len();
+        while !BogoSort::is_sorted(arr, arr_length) {
+            BogoSort::permute_randomly(arr, arr_length, &mut random_generator);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::bogo_sort;
+    use super::super::traits::SortMutable;
+    use super::BogoSort;
 
-    sorting_tests!(bogo_sort, inplace);
+    sorting_tests!(BogoSort::sort, inplace);
 }

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -40,10 +40,11 @@ mod selection_sort;
 mod shell_sort;
 mod stooge_sort;
 mod tim_sort;
+mod traits;
 
 use std::fmt;
 
-pub use self::bogo_sort::bogo_sort;
+pub use self::bogo_sort::BogoSort;
 pub use self::bubble_sort::bubble_sort;
 pub use self::bucket_sort::bucket_sort;
 pub use self::cocktail_shaker_sort::cocktail_shaker_sort;

--- a/src/sorting/traits.rs
+++ b/src/sorting/traits.rs
@@ -1,0 +1,7 @@
+pub trait Sort<T: Ord> {
+    fn sort(arr: &[T]) -> [T];
+}
+
+pub trait SortMutable<T: Ord> {
+    fn sort(arr: &mut [T]);
+}

--- a/src/sorting/traits.rs
+++ b/src/sorting/traits.rs
@@ -1,7 +1,11 @@
-pub trait Sort<T: Ord> {
-    fn sort(arr: &[T]) -> [T];
+pub trait Sorter<T> {
+    fn sort(arr: &[T]) -> [T]
+    where
+        T: Ord + Copy;
 }
 
-pub trait SortMutable<T: Ord> {
-    fn sort(arr: &mut [T]);
+pub trait MutableSorter<T> {
+    fn sort(arr: &mut [T])
+    where
+        T: Ord;
 }


### PR DESCRIPTION
Hi Alex,

Referring to PR #48, I have added two traits:
- Sort
- SortMutable

in an attempt to unify the sorting algorithms behind structs that expose the sort method.

Not sure how complete the feature needs to be, but I believe the PR would be too large at that point to be easily reviewable. I was considering submitting the traits for 1 algorithm at a time, modifying those that do not adhere to the trait properties.

I wanted to get into contributing to OSS, and I thought your library would be a great place to start. Any comments are welcome.