### PR TITLE
refactor(combsort): implement MutableSorter trait for CombSorter

### DIFF
--- a/src/sorting/comb_sort.rs
+++ b/src/sorting/comb_sort.rs
@@ -1,19 +1,28 @@
-pub fn comb_sort<T: Ord>(arr: &mut [T]) {
-    let mut gap = arr.len();
-    let shrink = 1.3;
-    let mut sorted = false;
+use super::traits::MutableSorter;
 
-    while !sorted {
-        gap = (gap as f32 / shrink).floor() as usize;
-        if gap <= 1 {
-            gap = 1;
-            sorted = true;
-        }
-        for i in 0..arr.len() - gap {
-            let j = i + gap;
-            if arr[i] > arr[j] {
-                arr.swap(i, j);
-                sorted = false;
+pub struct CombSort;
+
+impl<T> MutableSorter<T> for CombSort {
+    fn sort(arr: &mut [T])
+    where
+        T: Ord,
+    {
+        let mut gap = arr.len();
+        let shrink = 1.3;
+        let mut sorted = false;
+
+        while !sorted {
+            gap = (gap as f32 / shrink).floor() as usize;
+            if gap <= 1 {
+                gap = 1;
+                sorted = true;
+            }
+            for i in 0..arr.len() - gap {
+                let j = i + gap;
+                if arr[i] > arr[j] {
+                    arr.swap(i, j);
+                    sorted = false;
+                }
             }
         }
     }
@@ -21,27 +30,8 @@ pub fn comb_sort<T: Ord>(arr: &mut [T]) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::CombSort;
+    use super::MutableSorter;
 
-    sorting_tests!(comb_sort, inplace);
-
-    #[test]
-    fn descending() {
-        //descending
-        let mut ve1 = vec![6, 5, 4, 3, 2, 1];
-        comb_sort(&mut ve1);
-        for i in 0..ve1.len() - 1 {
-            assert!(ve1[i] <= ve1[i + 1]);
-        }
-    }
-
-    #[test]
-    fn ascending() {
-        //pre-sorted
-        let mut ve2 = vec![1, 2, 3, 4, 5, 6];
-        comb_sort(&mut ve2);
-        for i in 0..ve2.len() - 1 {
-            assert!(ve2[i] <= ve2[i + 1]);
-        }
-    }
+    sorting_tests!(CombSort::sort, inplace);
 }

--- a/src/sorting/macros.rs
+++ b/src/sorting/macros.rs
@@ -34,6 +34,13 @@ macro_rules! sorting_tests {
             $sorter(&mut array);
             assert_sorted!(&array);
         }
+
+        #[test]
+        fn descending() {
+            let mut array = [6, 5, 4, 3, 2, 1];
+            $sorter(&mut array);
+            assert_sorted!(&array);
+        }
     };
 
     ($sorter: expr) => {

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -48,7 +48,7 @@ pub use self::bogo_sort::BogoSort;
 pub use self::bubble_sort::BubbleSort;
 pub use self::bucket_sort::bucket_sort;
 pub use self::cocktail_shaker_sort::cocktail_shaker_sort;
-pub use self::comb_sort::comb_sort;
+pub use self::comb_sort::CombSort;
 pub use self::counting_sort::counting_sort;
 pub use self::cycle_sort::cycle_sort;
 pub use self::exchange_sort::exchange_sort;

--- a/src/sorting/radix_sort.rs
+++ b/src/sorting/radix_sort.rs
@@ -48,13 +48,6 @@ mod tests {
     }
 
     #[test]
-    fn descending() {
-        let mut v = vec![201, 127, 64, 37, 24, 4, 1];
-        radix_sort(&mut v);
-        assert_sorted!(&v);
-    }
-
-    #[test]
     fn ascending() {
         let mut v = vec![1, 4, 24, 37, 64, 127, 201];
         radix_sort(&mut v);


### PR DESCRIPTION
- Implementing the MutableSorter trait for CombSorter
- Standardized the tests by adding the descending test case to the macro and removing it from tests that use it
