### PR TITLE
feat: modified queue to use VecDeque instead of Vec

### DIFF
--- a/src/data_structures/queue.rs
+++ b/src/data_structures/queue.rs
@@ -1,15 +1,18 @@
+use std::collections::VecDeque;
+
 pub struct Queue<T> {
-    vec: Vec<T>,
+    vec: VecDeque<T>,
 }
 
 impl<T> Queue<T> {
     pub fn new() -> Self {
-        Queue { vec: Vec::new() }
+        Queue {
+            vec: VecDeque::new(),
+        }
     }
 
-    pub fn enqueue(&mut self, item: T) -> bool {
-        self.vec.push(item);
-        true
+    pub fn enqueue(&mut self, item: T) {
+        self.vec.push_back(item);
     }
 
     pub fn len(&self) -> usize {
@@ -21,15 +24,11 @@ impl<T> Queue<T> {
     }
 
     pub fn peek(&self) -> Option<&T> {
-        self.vec.first()
+        self.vec.front()
     }
 
     pub fn dequeue(&mut self) -> Option<T> {
-        if self.is_empty() {
-            None
-        } else {
-            Some(self.vec.remove(0))
-        }
+        self.vec.pop_front()
     }
 }
 


### PR DESCRIPTION
Also removed pointless return value of Queue::enqueue (if it fails it panics)

The original implementation's dequeue runs with O(n) efficiency, as pointed out by Vec::remove's documentation:
> Note: Because this shifts over the remaining elements, it has a worst-case performance of O(n).